### PR TITLE
Fix: pip install medimeta

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ is welcome.**
 The toolbox can be installed via pip:
 
 ```bash
-pip install medimeta-pytorch
+pip install medimeta
 ```
 
 ## Basic Usage


### PR DESCRIPTION
Hi Stefano, 

Thanks a lot for this great work and for uploading all the datasets to Zenodo, this is really valuable! 

I just started playing around and I guess the pip install note was wrong (?).
I tried to install via `pip install medimeta-pytorch` but I got:

```
ERROR: Could not find a version that satisfies the requirement medimeta-pytorch (from versions: none)
ERROR: No matching distribution found for medimeta-pytorch
```

Then, looking at the `project.toml`, I found out that the name was actually `medimeta`.
https://github.com/StefanoWoerner/medimeta-pytorch/blob/3540b011484b9590d9a242bc74e6e7d9882cfad4/pyproject.toml#L6

Then with `pip install medimeta` I was actually able to install it and to create the dataset as described in the tutorial.

Thanks again! 

Best,
Francesco